### PR TITLE
Correção da refatoração.

### DIFF
--- a/src/PCF/PCF.SPA/Services/AuthManagerService.cs
+++ b/src/PCF/PCF.SPA/Services/AuthManagerService.cs
@@ -44,6 +44,7 @@ namespace PCF.SPA.Services
                     var token = await response.Content.ReadAsStringAsync();
                     if (!string.IsNullOrWhiteSpace(token))
                     {
+                        token = token.Trim('"');
                         await SaveTokenAsync(token);
                         NotifyAuthenticationStateChanged();
                         return true;


### PR DESCRIPTION
faltava remover as aspas que era uma correção anterior.