### PR TITLE
Correção ao excluir categoria.

### DIFF
--- a/src/PCF/PCF.API/Controllers/CategoriasController.cs
+++ b/src/PCF/PCF.API/Controllers/CategoriasController.cs
@@ -74,6 +74,11 @@ namespace PCF.API.Controllers
             if (categoria is null)
             {
                 return TypedResults.NotFound();
+            } 
+
+            if (await categoriaService.HasBudgetAssociationAsync(categoria))
+            {
+                return TypedResults.BadRequest(new List<string> { "Categoria possui orçamentos associados e não pode ser excluida." });
             }
 
             var result = await categoriaService.DeleteAsync(id);

--- a/src/PCF/PCF.Core/Interface/ICategoriaRepository.cs
+++ b/src/PCF/PCF.Core/Interface/ICategoriaRepository.cs
@@ -8,7 +8,7 @@ namespace PCF.Core.Interface
 
         Task<Categoria?> GetByIdAsync(int id, int usuarioId);
         Task<Categoria?> GetGeralByIdAsync(int id);
-
+        Task<bool> HasBudgetAssociationAsync(Categoria categoria);
         Task<bool> CheckIfExistsByNomeAsync(int currentId, string nome, int usuarioId);
     }
 }

--- a/src/PCF/PCF.Core/Interface/ICategoriaService.cs
+++ b/src/PCF/PCF.Core/Interface/ICategoriaService.cs
@@ -11,6 +11,7 @@ namespace PCF.Core.Interface
         Task<Result> DeleteAsync(int id);
 
         Task<Result> UpdateAsync(Categoria categoria);
+        Task<bool> HasBudgetAssociationAsync(Categoria categoria);
 
         Task<Result<int>> AddAsync(Categoria categoria);
     }

--- a/src/PCF/PCF.Core/Repository/CategoriaRepository.cs
+++ b/src/PCF/PCF.Core/Repository/CategoriaRepository.cs
@@ -35,5 +35,11 @@ namespace PCF.Core.Repository
             return await _dbContext.Categorias
                 .AnyAsync(c => c.Nome == nome && c.UsuarioId == usuarioId && c.Id != currentId);
         }
+
+        public async Task<bool> HasBudgetAssociationAsync(Categoria categoria)
+        {
+            return await _dbContext.Orcamentos
+                .AnyAsync(o => o.CategoriaId == categoria.Id);
+        }
     }
 }

--- a/src/PCF/PCF.Core/Services/CategoriaService.cs
+++ b/src/PCF/PCF.Core/Services/CategoriaService.cs
@@ -49,6 +49,11 @@ namespace PCF.Core.Services
             return await repository.GetByIdAsync(id, appIdentityUser.GetUserId());
         }
 
+        public async Task<bool> HasBudgetAssociationAsync(Categoria categoria)
+        {
+           return await repository.HasBudgetAssociationAsync(categoria);
+        }
+
         public async Task<Result> UpdateAsync(Categoria categoria)
         {
             ArgumentNullException.ThrowIfNull(categoria);


### PR DESCRIPTION
Ao tentar excluir categoria que tem orçamento dava uma mensagem do vinculo com orçamento. verifiquei se existe orcamento para aquela categoria antes de excluir e melhorei a mensagem para o usuário.